### PR TITLE
Serialize custom attributes

### DIFF
--- a/AdaptorsFunctionality/src/au/gov/asd/tac/constellation/functionality/adaptors/dataaccess/plugins/enrichment/CustomInferencerPlugin.java
+++ b/AdaptorsFunctionality/src/au/gov/asd/tac/constellation/functionality/adaptors/dataaccess/plugins/enrichment/CustomInferencerPlugin.java
@@ -33,6 +33,8 @@ import au.gov.asd.tac.constellation.views.dataaccess.DataAccessPlugin;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Logger;
+import org.apache.commons.collections.map.LinkedMap;
+import org.apache.commons.collections.map.MultiKeyMap;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.query.QueryLanguage;
@@ -61,12 +63,13 @@ public class CustomInferencerPlugin extends SimpleEditPlugin implements DataAcce
     private static int layer_Mask = 9;
 
     final Map<String, String> subjectToType = new HashMap<>();
+    final MultiKeyMap literalToValue = MultiKeyMap.decorate(new LinkedMap());
     final Map<String, String> bnodeToSubject = new HashMap<>();
 
     @Override
     public void edit(GraphWriteMethods graph, final PluginInteraction interaction, final PluginParameters parameters) throws InterruptedException, PluginException {
         final GraphRecordStore results = new GraphRecordStore();
-        
+
         //populate model from query or the whole graph as required
         Model model = RDFUtilities.getGraphModel(graph);
 
@@ -88,7 +91,7 @@ public class CustomInferencerPlugin extends SimpleEditPlugin implements DataAcce
             conn.add(model);
 
             try (RepositoryResult<Statement> repositoryResult = conn.getStatements(null, null, null);) {
-                RDFUtilities.PopulateRecordStore(results, repositoryResult, subjectToType, layer_Mask);
+                RDFUtilities.PopulateRecordStore(results, repositoryResult, subjectToType, literalToValue, layer_Mask);
             }
 
         } finally {

--- a/AdaptorsFunctionality/src/au/gov/asd/tac/constellation/functionality/adaptors/dataaccess/plugins/enrichment/OWLApiInferencerPlugin.java
+++ b/AdaptorsFunctionality/src/au/gov/asd/tac/constellation/functionality/adaptors/dataaccess/plugins/enrichment/OWLApiInferencerPlugin.java
@@ -43,6 +43,8 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
+import org.apache.commons.collections.map.LinkedMap;
+import org.apache.commons.collections.map.MultiKeyMap;
 import org.eclipse.rdf4j.RDF4JException;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Statement;
@@ -92,6 +94,7 @@ public class OWLApiInferencerPlugin extends RecordStoreQueryPlugin implements Da
 
     final private static int layer_Mask = 9;
 
+    final MultiKeyMap literalToValue = MultiKeyMap.decorate(new LinkedMap());
     final Map<String, String> subjectToType = new HashMap<>();
     final Map<String, String> bnodeToSubject = new HashMap<>();
 
@@ -298,7 +301,7 @@ public class OWLApiInferencerPlugin extends RecordStoreQueryPlugin implements Da
                     RepositoryResult<Statement> statements = conn.getStatements(null, null, null, true);
 
                     try {
-                        RDFUtilities.PopulateRecordStore(recordStore, statements, subjectToType, layer_Mask);
+                        RDFUtilities.PopulateRecordStore(recordStore, statements, subjectToType, literalToValue, layer_Mask);
                     } finally {
                         statements.close();
                     }

--- a/AdaptorsFunctionality/src/au/gov/asd/tac/constellation/functionality/adaptors/dataaccess/plugins/enrichment/RDFSInferencerPlugin.java
+++ b/AdaptorsFunctionality/src/au/gov/asd/tac/constellation/functionality/adaptors/dataaccess/plugins/enrichment/RDFSInferencerPlugin.java
@@ -131,6 +131,7 @@ public class RDFSInferencerPlugin extends RecordStoreQueryPlugin implements Data
         super.edit(wg, interaction, parameters);
 
         RDFUtilities.setRDFTypesVertexAttribute(wg, subjectToType);
+        RDFUtilities.setLiteralValuesVertexAttribute(wg, literalToValue);
 
         // Overwrite BNODES in the graph attribute with inferred data
         final int rdfBlankNodesAttributeId = RDFConcept.GraphAttribute.RDF_BLANK_NODES.ensure(wg);

--- a/AdaptorsFunctionality/src/au/gov/asd/tac/constellation/functionality/adaptors/dataaccess/plugins/enrichment/RDFSInferencerPlugin.java
+++ b/AdaptorsFunctionality/src/au/gov/asd/tac/constellation/functionality/adaptors/dataaccess/plugins/enrichment/RDFSInferencerPlugin.java
@@ -42,6 +42,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
+import org.apache.commons.collections.map.LinkedMap;
+import org.apache.commons.collections.map.MultiKeyMap;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.repository.Repository;
@@ -64,6 +66,7 @@ public class RDFSInferencerPlugin extends RecordStoreQueryPlugin implements Data
 
     private static final int layer_Mask = 9;
     private final Map<String, String> subjectToType = new HashMap<>();
+    final MultiKeyMap literalToValue = MultiKeyMap.decorate(new LinkedMap());
     private final Set<Statement> bNodeStatements = new HashSet<>();
 
     private static final Logger LOGGER = Logger.getLogger(RDFSInferencerPlugin.class.getName());
@@ -92,12 +95,12 @@ public class RDFSInferencerPlugin extends RecordStoreQueryPlugin implements Data
                     )
             );
 
-            try ( RepositoryConnection conn = repo.getConnection()) {
+            try (RepositoryConnection conn = repo.getConnection()) {
                 conn.add(model);
 
                 // retrieve all RDFS infered statements
-                try ( RepositoryResult<Statement> repositoryResult = conn.getStatements(null, null, null);) {
-                    RDFUtilities.PopulateRecordStore(inferredRecordStore, repositoryResult, subjectToType, bNodeStatements, layer_Mask);
+                try (RepositoryResult<Statement> repositoryResult = conn.getStatements(null, null, null);) {
+                    RDFUtilities.PopulateRecordStore(inferredRecordStore, repositoryResult, subjectToType, literalToValue, bNodeStatements, layer_Mask);
                 }
             }
         } finally {

--- a/AdaptorsFunctionality/src/au/gov/asd/tac/constellation/functionality/adaptors/dataaccess/plugins/hopping/QueryRDFDataSourcesPlugin.java
+++ b/AdaptorsFunctionality/src/au/gov/asd/tac/constellation/functionality/adaptors/dataaccess/plugins/hopping/QueryRDFDataSourcesPlugin.java
@@ -36,6 +36,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.apache.commons.collections.map.LinkedMap;
+import org.apache.commons.collections.map.MultiKeyMap;
 import org.eclipse.rdf4j.RDF4JException;
 import org.eclipse.rdf4j.query.GraphQuery;
 import org.eclipse.rdf4j.query.GraphQueryResult;
@@ -61,6 +63,7 @@ public class QueryRDFDataSourcesPlugin extends RecordStoreQueryPlugin implements
     //private static final String SOURCE_IDENTIFIER = GraphRecordStoreUtilities.SOURCE + VisualConcept.VertexAttribute.IDENTIFIER;
     private static int layer_Mask = 5;
 
+    final MultiKeyMap literalToValue = MultiKeyMap.decorate(new LinkedMap());
     final Map<String, String> subjectToType = new HashMap<>();
     final Map<String, String> bnodeToSubject = new HashMap<>();
 
@@ -103,7 +106,7 @@ public class QueryRDFDataSourcesPlugin extends RecordStoreQueryPlugin implements
                 GraphQuery graphQuery = conn.prepareGraphQuery(QueryLanguage.SPARQL, qb.toString());
 
                 try (GraphQueryResult queryResult = graphQuery.evaluate()) {
-                    RDFUtilities.PopulateRecordStore(recordStore, queryResult, subjectToType, layer_Mask);
+                    RDFUtilities.PopulateRecordStore(recordStore, queryResult, subjectToType, literalToValue, layer_Mask);
 
                 } catch (RDF4JException e) {
                     LOGGER.log(Level.SEVERE, "An error occured: {0}", e);

--- a/AdaptorsFunctionality/src/au/gov/asd/tac/constellation/functionality/adaptors/dataaccess/plugins/sail/ConstellationSail.java
+++ b/AdaptorsFunctionality/src/au/gov/asd/tac/constellation/functionality/adaptors/dataaccess/plugins/sail/ConstellationSail.java
@@ -29,6 +29,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.apache.commons.collections.map.LinkedMap;
+import org.apache.commons.collections.map.MultiKeyMap;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.TreeModel;
@@ -165,9 +167,8 @@ public class ConstellationSail extends AbstractNotifyingSail implements Federate
     @Deprecated
     public void writeModelToGraph() {
         final GraphRecordStore recordStore = new GraphRecordStore();
-
         store.getExplicitSailSource().dataset(getDefaultIsolationLevel()).getStatements(null, null, null).stream().forEach((statement) -> {
-            RDFUtilities.processNextRecord(recordStore, statement, new HashMap<>(), new HashSet<>(), 0);
+            RDFUtilities.processNextRecord(recordStore, statement, new HashMap<>(), MultiKeyMap.decorate(new LinkedMap()), new HashSet<>(), 0);
         });
 
         WritableGraph writableGraph = null;

--- a/AdaptorsFunctionality/src/au/gov/asd/tac/constellation/functionality/adaptors/dataaccess/plugins/utilities/RDFUtilities.java
+++ b/AdaptorsFunctionality/src/au/gov/asd/tac/constellation/functionality/adaptors/dataaccess/plugins/utilities/RDFUtilities.java
@@ -25,6 +25,7 @@ import au.gov.asd.tac.constellation.graph.processing.GraphRecordStoreUtilities;
 import au.gov.asd.tac.constellation.graph.schema.analytic.concept.AnalyticConcept;
 import au.gov.asd.tac.constellation.graph.schema.rdf.concept.RDFConcept;
 import au.gov.asd.tac.constellation.graph.schema.visual.concept.VisualConcept;
+import au.gov.asd.tac.constellation.utilities.text.SeparatorConstants;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -32,6 +33,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.apache.commons.collections.keyvalue.MultiKey;
+import org.apache.commons.collections.map.MultiKeyMap;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
@@ -48,41 +51,50 @@ import org.eclipse.rdf4j.repository.RepositoryResult;
 
 public class RDFUtilities {
 
+    final static boolean VERBOSE = true;
+    final static SimpleValueFactory FACTORY = SimpleValueFactory.getInstance();
+    private final static String SEPARATOR_TERM = SeparatorConstants.COMMA;
+
     final static Map<String, Resource> bnodeToSubject = new HashMap<>();
     private static final Logger LOGGER = Logger.getLogger(ImportFromRDFPlugin.class.getName());
     private static final int layer_Mask = 3;
 
-    public static void PopulateRecordStore(GraphRecordStore recordStore, RepositoryResult<Statement> repositoryResult, Map<String, String> subjectToType, int layerMask) {
+    public static void PopulateRecordStore(GraphRecordStore recordStore, RepositoryResult<Statement> repositoryResult, Map<String, String> subjectToType, MultiKeyMap literalToValue, int layerMask) {
         // TODO- need to remove this if the bNodeStatements are added into the graph attribute by other plugins
-        PopulateRecordStore(recordStore, repositoryResult, subjectToType, new HashSet<>(), layerMask);
+        PopulateRecordStore(recordStore, repositoryResult, subjectToType, literalToValue, new HashSet<>(), layerMask);
     }
 
-    public static void PopulateRecordStore(GraphRecordStore recordStore, GraphQueryResult res, Map<String, String> subjectToType, int layerMask) {
+    public static void PopulateRecordStore(GraphRecordStore recordStore, GraphQueryResult res, Map<String, String> subjectToType, MultiKeyMap literalToValue, int layerMask) {
         // TODO- need to remove this if the bNodeStatements are added into the graph attribute by other plugins
-        PopulateRecordStore(recordStore, res, subjectToType, new HashSet<>(), layerMask);
+        PopulateRecordStore(recordStore, res, subjectToType, literalToValue, new HashSet<>(), layerMask);
     }
 
-    public static void PopulateRecordStore(GraphRecordStore recordStore, RepositoryResult<Statement> repositoryResult, Map<String, String> subjectToType, Set<Statement> bNodeStatements, int layerMask) {
+    public static void PopulateRecordStore(GraphRecordStore recordStore, RepositoryResult<Statement> repositoryResult, Map<String, String> subjectToType, MultiKeyMap literalToValue, Set<Statement> bNodeStatements, int layerMask) {
         for (Statement statement : repositoryResult) {
-            processNextRecord(recordStore, statement, subjectToType, bNodeStatements, layerMask);
+            processNextRecord(recordStore, statement, subjectToType, literalToValue, bNodeStatements, layerMask);
         }
     }
 
-    public static void PopulateRecordStore(GraphRecordStore recordStore, GraphQueryResult res, Map<String, String> subjectToType, Set<Statement> bNodeStatements, int layerMask) {
+    public static void PopulateRecordStore(GraphRecordStore recordStore, GraphQueryResult res, Map<String, String> subjectToType, MultiKeyMap literalToValue, Set<Statement> bNodeStatements, int layerMask) {
         while (res.hasNext()) {
-            processNextRecord(recordStore, res.next(), subjectToType, bNodeStatements, layerMask);
+            processNextRecord(recordStore, res.next(), subjectToType, literalToValue, bNodeStatements, layerMask);
         }
     }
 
-    public static void processNextRecord(GraphRecordStore recordStore, Statement statement, Map<String, String> subjectToType, Set<Statement> bNodeStatements, int layerMask) {
-        LOGGER.info("Processing next record...");
+    public static void processNextRecord(GraphRecordStore recordStore, Statement statement, Map<String, String> subjectToType, MultiKeyMap literalToValue, Set<Statement> bNodeStatements, int layerMask) {
+        if (VERBOSE) {
+            LOGGER.info("Processing next record...");
+        }
+
         final Resource subject = statement.getSubject();
         final IRI predicate = statement.getPredicate();
         final Value object = statement.getObject();
         final Resource context = statement.getContext();
         Resource parentIRISubject = statement.getPredicate(); // TODO: is this needed as we already have predicate with the same value?
 
-        LOGGER.log(Level.INFO, "Saw Subject: {0}, Predicate: {1}, Object: {2}, Context: {3}", new Object[]{subject, predicate, object, context});
+        if (VERBOSE) {
+            LOGGER.log(Level.INFO, "Saw Subject: {0}, Predicate: {1}, Object: {2}, Context: {3}", new Object[]{subject, predicate, object, context});
+        }
 
         boolean addAttributes = false;
         boolean objectIsIRI = false;
@@ -114,7 +126,10 @@ public class RDFUtilities {
 //
 //            }
             } else {
-                LOGGER.log(Level.WARNING, "Unknown subject type: {0}, dropping", subject);
+                if (VERBOSE) {
+                    LOGGER.log(Level.WARNING, "Unknown subject type: {0}, dropping", subject);
+                }
+
             }
 
             // PROCESS: Predicate
@@ -136,10 +151,16 @@ public class RDFUtilities {
 //            objectIsBNode = true;
 //            LOGGER.log(Level.WARNING, "BNode object type: {0}, could be dropping, if no further Bnode with same string in the subject is found", objectName);
             } else {
-                LOGGER.log(Level.WARNING, "Unknown object type: {0}, dropping", object);
+                if (VERBOSE) {
+                    LOGGER.log(Level.WARNING, "Unknown object type: {0}, dropping", object);
+                }
+
             }
 
-            LOGGER.log(Level.INFO, "Processing Subject: {0}, Predicate: {1}, Object: {2}, Context: {3}", new Object[]{subjectName, predicateName, objectName, context});
+            if (VERBOSE) {
+                LOGGER.log(Level.INFO, "Processing Subject: {0}, Predicate: {1}, Object: {2}, Context: {3}", new Object[]{subjectName, predicateName, objectName, context});
+            }
+
 //        if (objectIsBNode) {
 //            if (subject instanceof IRI) {//Currently the subject can only be a URI or blank node- if they ever support Literals, need to change this
 //                LOGGER.log(Level.WARNING, "RDF IDENTIFIER = ");
@@ -154,25 +175,47 @@ public class RDFUtilities {
 //
 //        } else
             if (addAttributes || ("type".equals(predicateName) && subject instanceof BNode)) { // literal object values are added as Vertex properties
-                LOGGER.log(Level.INFO, "Adding Literal \"{0}\"", objectName);
+                if (VERBOSE) {
+                    LOGGER.log(Level.INFO, "Adding Literal \"{0}\"", objectName);
+                }
+
                 recordStore.add();
                 if (subject instanceof IRI) {//Currently the subject can only be a URI or blank node- if they ever support Literals, need to change this
                     recordStore.set(GraphRecordStoreUtilities.SOURCE + RDFConcept.VertexAttribute.RDFIDENTIFIER, StringUtils.trim(subject.stringValue()).toLowerCase());
                 } else if (subject instanceof BNode) {
                     //recordStore.set(GraphRecordStoreUtilities.SOURCE + VisualConcept.VertexAttribute.RDFIDENTIFIER, parentIRISubject.stringValue());//or skip overwriting
-                    LOGGER.log(Level.WARNING, "Subject is a BNode. Add the triples in an attribute of " + parentIRISubject.stringValue());
+                    if (VERBOSE) {
+                        LOGGER.log(Level.WARNING, "Subject is a BNode. Add the triples in an attribute of " + parentIRISubject.stringValue());
+                    }
                 } else {
-                    LOGGER.log(Level.WARNING, " Invalid RDF IDENTIFIER for subject", subject.stringValue());
+                    if (VERBOSE) {
+                        LOGGER.log(Level.WARNING, " Invalid RDF IDENTIFIER for subject", subject.stringValue());
+                    }
                 }
+
+                // ***************************** STORING PREDICATE LITERAL ***********************************
+                // Handling the case of two entries for the same predicate.
+                final String key1 = predicate.toString();
+                final String key2 = StringUtils.trim((subject != null) ? subject.stringValue() : "").toLowerCase();
+
+                String value = (object != null) ? object.toString() : "";
+                if (literalToValue.containsKey(key1, key2)) {
+                    value += SEPARATOR_TERM + (String) literalToValue.get(key1, key2);
+                }
+                literalToValue.put(key1, key2, value);
+
+                recordStore.set(GraphRecordStoreUtilities.SOURCE + key1, value);
                 recordStore.set(GraphRecordStoreUtilities.SOURCE + VisualConcept.VertexAttribute.IDENTIFIER, subjectName);
-                recordStore.set(GraphRecordStoreUtilities.SOURCE + predicateName, statement); //need to handle multiple attributes with the same predicatename
                 recordStore.set(GraphRecordStoreUtilities.SOURCE + LayersConcept.VertexAttribute.LAYER_MASK, Integer.toString(layerMask));
+
             } else if ("type".equals(predicateName)) {//TODO need to handle TYPE of BNODES seperately here
                 recordStore.add();
                 if (subject instanceof IRI) {
                     recordStore.set(GraphRecordStoreUtilities.SOURCE + RDFConcept.VertexAttribute.RDFIDENTIFIER, StringUtils.trim(subject.stringValue()).toLowerCase());
                 } else {//Subject is  a BNode
-                    LOGGER.log(Level.WARNING, "Subject is  a BNode. Added the triples above in an attribute of " + parentIRISubject.stringValue());//or skip overwriting-can it hit hrer?yes  TYPE of BNODES
+                    if (VERBOSE) {
+                        LOGGER.log(Level.WARNING, "Subject is  a BNode. Added the triples above in an attribute of " + parentIRISubject.stringValue());
+                    }//or skip overwriting-can it hit hrer?yes  TYPE of BNODES
                 }
                 recordStore.set(GraphRecordStoreUtilities.SOURCE + VisualConcept.VertexAttribute.IDENTIFIER, subjectName);
                 recordStore.set(GraphRecordStoreUtilities.SOURCE + LayersConcept.VertexAttribute.LAYER_MASK, Integer.toString(layerMask));
@@ -190,7 +233,9 @@ public class RDFUtilities {
                     recordStore.add();
                 }
                 if (!(subject instanceof IRI && predicate instanceof IRI)) {
-                    LOGGER.log(Level.WARNING, "Invalid RDF IDENTIFIER. Subject: " + subject.stringValue() + " or Predicate: " + predicate.stringValue());
+                    if (VERBOSE) {
+                        LOGGER.log(Level.WARNING, "Invalid RDF IDENTIFIER. Subject: " + subject.stringValue() + " or Predicate: " + predicate.stringValue());
+                    }
                 }
                 recordStore.set(GraphRecordStoreUtilities.SOURCE + RDFConcept.VertexAttribute.RDFIDENTIFIER, StringUtils.trim(subject.stringValue()).toLowerCase());
                 recordStore.set(GraphRecordStoreUtilities.SOURCE + VisualConcept.VertexAttribute.IDENTIFIER, subjectName);
@@ -200,14 +245,16 @@ public class RDFUtilities {
                     recordStore.set(GraphRecordStoreUtilities.DESTINATION + RDFConcept.VertexAttribute.RDFIDENTIFIER, StringUtils.trim(object.stringValue()).toLowerCase());
                     recordStore.set(GraphRecordStoreUtilities.DESTINATION + VisualConcept.VertexAttribute.IDENTIFIER, objectName);
                     recordStore.set(GraphRecordStoreUtilities.DESTINATION + LayersConcept.VertexAttribute.LAYER_MASK, Integer.toString(layerMask));
-					
+
                     recordStore.set(GraphRecordStoreUtilities.TRANSACTION + RDFConcept.TransactionAttribute.RDFIDENTIFIER, StringUtils.trim(predicate.stringValue()).toLowerCase());
                     recordStore.set(GraphRecordStoreUtilities.TRANSACTION + VisualConcept.TransactionAttribute.IDENTIFIER, predicateName);
                     recordStore.set(GraphRecordStoreUtilities.TRANSACTION + AnalyticConcept.TransactionAttribute.TYPE, AnalyticConcept.TransactionType.CORRELATION);//TODO FIX TYPE
                     recordStore.set(GraphRecordStoreUtilities.TRANSACTION + LayersConcept.VertexAttribute.LAYER_MASK, Integer.toString(layerMask));
                 }
             } else {
-                LOGGER.log(Level.WARNING, "Predicate: {0} not mapped.", predicateName);
+                if (VERBOSE) {
+                    LOGGER.log(Level.WARNING, "Predicate: {0} not mapped.", predicateName);
+                }
             }
         }
     }
@@ -241,14 +288,42 @@ public class RDFUtilities {
         }
     }
 
-    public static void addNodeAttributes(final GraphReadMethods graph, Model model, int vertexId) {
-        //Loops through all of the Node attributes and add the tripples stored there
+    public static void addNodeAttributes(final GraphReadMethods graph, final Model model, final int vertexId) {
         final int vertexAttributeCount = graph.getAttributeCount(GraphElementType.VERTEX);
+        final int vertexRDFIdentifierAttributeId = RDFConcept.VertexAttribute.RDFIDENTIFIER.get(graph);
+
+        //Loops through all of the Node attributes and add the triples stored there, back into the model
         for (int vertexAttributePosition = 0; vertexAttributePosition < vertexAttributeCount; vertexAttributePosition++) {
+            // Grab the subject, predicate and object from RDF_Identifier, AttributeName and AttributeValue respectively.
+            // Create a statement from this, and store that back into the model.
+            // Do not create a null literal object
             final int vertexAttributeId = graph.getAttribute(GraphElementType.VERTEX, vertexAttributePosition);
-            Statement statement = graph.getObjectValue(vertexAttributeId, vertexId);
-            if (statement != null) {
-                model.add(statement);
+            final String vxAttributeName = graph.getAttributeName(vertexAttributeId);
+            final String rdfObject = graph.getStringValue(vertexAttributeId, vertexId);
+
+            // only make a new statement from the attributes whose name is an IRI - meaning it is the predicate.
+            // Tried to "validate" the IRI using instanceof, also createIRI, but none validated it.
+            // TODO: Find a suitable way to ensure the axAttributeName is an IRI. (and not Identifier/Label/Raw etc.)
+            if (vxAttributeName.startsWith("http") && rdfObject != null) {
+                final String rdfIdentifierSubject = graph.getStringValue(vertexRDFIdentifierAttributeId, vertexId);
+                final IRI subject = FACTORY.createIRI(rdfIdentifierSubject);
+                final IRI predicate = FACTORY.createIRI(vxAttributeName);
+                if (rdfObject.contains(SEPARATOR_TERM)) {
+                    // TODO: This is potentially unsafe because it is not guaranteed that the object will not
+                    // contain a comma as part of it's value. Possible solution is to use a different SEPARATOR_TERM,
+                    // or implement multi-valued attributes.
+                    for (final String csvItem : rdfObject.split(SEPARATOR_TERM)) {
+                        final Literal object = FACTORY.createLiteral(csvItem);
+                        model.add(FACTORY.createStatement(subject, predicate, object));
+                    }
+                } else {
+                    final Literal object = FACTORY.createLiteral(rdfObject);
+                    if (VERBOSE) {
+                        LOGGER.log(Level.INFO, "Found IRI Attribute: {0}, {1}, {2}", new Object[]{rdfIdentifierSubject, vxAttributeName, rdfObject});
+                    }
+                    model.add(FACTORY.createStatement(subject, predicate, object));
+                }
+
             }
         }
     }
@@ -265,8 +340,9 @@ public class RDFUtilities {
         //final String source = graph.getStringValue(vertexSourceAttributeId, vertexId);
         final String rdfTypes = graph.getStringValue(vertexRDFTypesAttributeId, vertexId);
 
-        final Resource subject = SimpleValueFactory.getInstance().createIRI(getIRI(rdfIdentifier));
+        final Resource subject = FACTORY.createIRI(getIRI(rdfIdentifier));
 
+        addNodeAttributes(graph, model, vertexId);
         //Iterate over multiple values in RDF_TYPE and add multiple entries to the RDF collection
         if (rdfTypes != null) {
             final String[] rdfTypesArray = Arrays.stream(rdfTypes.split(","))
@@ -275,9 +351,9 @@ public class RDFUtilities {
 
             //if (rdfTypesArray.length > 0) {
             for (int i = 0; i < rdfTypesArray.length; i++) {
-                final Value object = SimpleValueFactory.getInstance().createIRI(getIRI(rdfTypesArray[i])); // TODO: this will require a lookup to convert a Consty type to RDF type
+                final Value object = FACTORY.createIRI(getIRI(rdfTypesArray[i])); // TODO: this will require a lookup to convert a Consty type to RDF type
 
-                model.add(SimpleValueFactory.getInstance().createStatement(subject, RDF.TYPE, object));
+                model.add(FACTORY.createStatement(subject, RDF.TYPE, object));
             }
         }
     }
@@ -303,11 +379,11 @@ public class RDFUtilities {
         final String transactionRDFIdentifier = graph.getStringValue(transactionRDFIdentifierAttributeId, transactionId);
         //final String transactionType = graph.getStringValue(transactionTypeAttributeId, transactionId);
 
-        final Resource subject = SimpleValueFactory.getInstance().createIRI(getIRI(sourceRDFIdentifier));
-        final IRI predicate = SimpleValueFactory.getInstance().createIRI(getIRI(transactionRDFIdentifier));
-        final Value object = SimpleValueFactory.getInstance().createIRI(getIRI(destinationRDFIdentifier));
+        final Resource subject = FACTORY.createIRI(getIRI(sourceRDFIdentifier));
+        final IRI predicate = FACTORY.createIRI(getIRI(transactionRDFIdentifier));
+        final Value object = FACTORY.createIRI(getIRI(destinationRDFIdentifier));
 
-        model.add(SimpleValueFactory.getInstance().createStatement(subject, predicate, object));
+        model.add(FACTORY.createStatement(subject, predicate, object));
     }
 
     public static void addBlankNodesToModel(final GraphReadMethods graph, Model model) {
@@ -318,6 +394,37 @@ public class RDFUtilities {
             for (final Statement statement : bNodeStatements) {
                 model.add(statement);
             }
+        }
+    }
+
+    /**
+     * Takes all entries from the literalToValue map and writes the contents to
+     * the correct nodes.
+     *
+     * This was necessary because it did not seem possible to view previous
+     * entries while iterating each statement to check for multiple entries for
+     * each triple?.
+     *
+     * @param wg
+     * @param literalToValue
+     */
+    public static void setLiteralValuesVertexAttribute(final GraphWriteMethods wg, final MultiKeyMap literalToValue) {
+        final int vertexIdentifierAttributeId = RDFConcept.VertexAttribute.RDFIDENTIFIER.ensure(wg);
+        final int graphVertexCount = wg.getVertexCount();
+
+        for (int position = 0; position < graphVertexCount; position++) {
+            final int currentVertexId = wg.getVertex(position);
+            final String RDFidentifier = wg.getStringValue(vertexIdentifierAttributeId, currentVertexId);
+
+            literalToValue.forEach((key, value) -> {
+                final String key2 = (String) ((MultiKey) key).getKey(1);
+                if (RDFidentifier.equals(key2)) {
+                    final String key1 = (String) ((MultiKey) key).getKey(0);
+                    // create new attribute that is of the name in key1
+                    final int newAttribute = wg.addAttribute(GraphElementType.VERTEX, "string", key1, "Auto-Generated RDF Predicate IRI", null, null);
+                    wg.setStringValue(newAttribute, currentVertexId, (String) value);
+                }
+            });
         }
     }
 

--- a/AdaptorsRDFSchema/src/au/gov/asd/tac/constellation/graph/schema/rdf/RDFSchemaFactory.java
+++ b/AdaptorsRDFSchema/src/au/gov/asd/tac/constellation/graph/schema/rdf/RDFSchemaFactory.java
@@ -97,7 +97,7 @@ public class RDFSchemaFactory extends AnalyticSchemaFactory {
         return new RDFSchema(this);
     }
 
-     @Override
+    @Override
     public List<SchemaAttribute> getKeyAttributes(final GraphElementType elementType) {
         final List<SchemaAttribute> keys;
         switch (elementType) {
@@ -129,7 +129,7 @@ public class RDFSchemaFactory extends AnalyticSchemaFactory {
         public void newGraph(final GraphWriteMethods graph) {
             super.newGraph(graph);
             ensureKeyAttributes(graph); // TODO: is this check required if its already done in super?
-            
+
             final int rdfBlankNodesAttributeId = RDFConcept.GraphAttribute.RDF_BLANK_NODES.ensure(graph);
         }
 
@@ -167,7 +167,7 @@ public class RDFSchemaFactory extends AnalyticSchemaFactory {
                 //if (type == null || type.isIncomplete()) {
 //                type = rdfTypes != null ? rdfTypes : SchemaVertexTypeUtilities.getDefaultType();
 //                type = graph.getSchema().resolveVertexType(type.toString());
-                    type = resolveVertexType(rdfTypes.toString());
+                type = resolveVertexType(rdfTypes.toString());
                 //}
 
                 if (type != null && type != SchemaVertexTypeUtilities.getDefaultType() && !type.equals(graph.getObjectValue(vertexTypeAttribute, vertexId))) {
@@ -175,13 +175,17 @@ public class RDFSchemaFactory extends AnalyticSchemaFactory {
                 }
 
             }
-             super.completeVertex(graph, vertexId);
+            super.completeVertex(graph, vertexId);
         }
 
         @Override
         public SchemaVertexType resolveVertexType(final String type) {
-//            LOGGER.info("called RDF resolve type");
 
+            // read file
+            //
+            // creating schemavertextypes
+            //
+//            LOGGER.info("called RDF resolve type");
             /**
              * TODO: Add logic here to look at the RDF type and figure out the
              * most appropriate Constellation type to use. We could use the
@@ -202,11 +206,11 @@ public class RDFSchemaFactory extends AnalyticSchemaFactory {
                 return SchemaVertexTypeUtilities.getType("Song");
             } else if (type.contains("http://neo4j.com/voc/music#Album")) {
                 return SchemaVertexTypeUtilities.getType("Music Album");
-             } else if (type.contains("http://www.w3.org/2002/07/owl#AnnotationProperty")
-                     || type.contains("http://neo4j.com/voc/music#Artist")
-                     || type.contains("http://www.w3.org/2000/01/rdf-schema#Class")
-                     || type.contains("http://www.w3.org/1999/02/22-rdf-syntax-ns#Property")
-                     || type.contains("http://www.w3.org/2000/01/rdf-schema#Resource")) {
+            } else if (type.contains("http://www.w3.org/2002/07/owl#AnnotationProperty")
+                    || type.contains("http://neo4j.com/voc/music#Artist")
+                    || type.contains("http://www.w3.org/2000/01/rdf-schema#Class")
+                    || type.contains("http://www.w3.org/1999/02/22-rdf-syntax-ns#Property")
+                    || type.contains("http://www.w3.org/2000/01/rdf-schema#Resource")) {
                 return SchemaVertexTypeUtilities.getType("RDF Test");
             }
 


### PR DESCRIPTION
This change stores the custom attributes as strings instead of objects. This allows them to be converted in the inferencing step. 
This change also adds a comma separated list as some entries into triples need to be stored in the same attribute for the same node. 

**Be aware that this PR has a few downsides.**
- It was necessary to get all custom attributes. There was not an easy way to do so. This ended up being a comparison of attribute name with the word "http". This could go wrong as a standard attribute can have http, and it would then be inference-ed back into the model and cause wrong knowledge.
- A multi-key map was used to store and concatenate multiple values read from statement iteration. Key 1 is the `RDF_Identifier` of the node, and Key 2 is the predicate. The value is the object. This map is then used to add the required attribute values (comma separated) to the graph. This could be bad as there is no guarantee that the other custom attributes cannot have a comma within their value.
- The above also means that if RDF_Identifier data is migrated to just Identifier, then this section of code should also be refactored to take that into account.

To test this change, I used the import from RDF plugin. I used the Attribute Editor to check the values within the custom attributes. I wanted to see a comma separated list on the items like `"LaReine"@en.`
I also wanted to ensure that once inferenced, the correct data went back into the model. I stepped with the debugger to ensure that the values were written correctly into the model again.

**Potential downside:**
I seen no possible way to make a statement with the same xml language tag `<rdfs:label xml:lang="en">LaReine</rdfs:label>` So in place of that, I have stored the item to look as follows (I think?): `<rdfs:label>"LaReine"@en</rdfs:label>`

constellation-app/constellation#840 (comment)