### PR TITLE
Prevent double notifications when running Data Access plugins.

### DIFF
--- a/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/enrichment/EnrichFromGMLPlugin.java
+++ b/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/enrichment/EnrichFromGMLPlugin.java
@@ -30,6 +30,7 @@ import au.gov.asd.tac.constellation.plugins.parameters.PluginParameter;
 import au.gov.asd.tac.constellation.plugins.parameters.PluginParameters;
 import au.gov.asd.tac.constellation.plugins.parameters.types.FileParameterType;
 import au.gov.asd.tac.constellation.plugins.parameters.types.FileParameterType.FileParameterValue;
+import au.gov.asd.tac.constellation.utilities.gui.NotifyDisplayer;
 import au.gov.asd.tac.constellation.views.dataaccess.plugins.DataAccessPlugin;
 import au.gov.asd.tac.constellation.views.dataaccess.plugins.DataAccessPluginCoreType;
 import au.gov.asd.tac.constellation.views.dataaccess.templates.RecordStoreQueryPlugin;
@@ -42,6 +43,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javafx.stage.FileChooser;
+import org.apache.commons.lang3.StringUtils;
 import org.openide.util.NbBundle.Messages;
 import org.openide.util.lookup.ServiceProvider;
 import org.openide.util.lookup.ServiceProviders;
@@ -149,18 +151,27 @@ public class EnrichFromGMLPlugin extends RecordStoreQueryPlugin implements DataA
             }
 
         } catch (final FileNotFoundException ex) {
-            interaction.notify(PluginNotificationLevel.ERROR, "File " + filename + " not found");
-            LOGGER.log(Level.SEVERE, ex, () -> "File " + filename + " not found");
+            final String errorMsg = StringUtils.isEmpty(filename) ? "File not specified" : "File not found: " + filename;
+            interaction.notify(PluginNotificationLevel.ERROR, errorMsg);
+            final Throwable fnfEx = new FileNotFoundException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
+            fnfEx.setStackTrace(ex.getStackTrace());
+            LOGGER.log(Level.SEVERE, fnfEx, () -> errorMsg);
         } catch (final IOException ex) {
-            interaction.notify(PluginNotificationLevel.ERROR, "Error reading file: " + filename);
-            LOGGER.log(Level.SEVERE, ex, () -> "Error reading file: " + filename);
+            final String errorMsg = StringUtils.isEmpty(filename) ? "File not specified " : "Error reading file: " + filename;
+            interaction.notify(PluginNotificationLevel.ERROR, errorMsg);
+            final Throwable ioEx = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
+            ioEx.setStackTrace(ex.getStackTrace());            
+            LOGGER.log(Level.SEVERE, ioEx, () -> errorMsg);
         } finally {
             if (in != null) {
                 try {
                     in.close();
                 } catch (final IOException ex) {
-                    interaction.notify(PluginNotificationLevel.ERROR, "Error reading file: " + filename);
-                    LOGGER.log(Level.SEVERE, ex, () -> "Error reading file: " + filename);
+                    final String errorMsg = StringUtils.isEmpty(filename) ? "File not specified " : "Error reading file: " + filename;
+                    interaction.notify(PluginNotificationLevel.ERROR, errorMsg);
+                    final Throwable ioEx = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
+                    ioEx.setStackTrace(ex.getStackTrace());            
+                    LOGGER.log(Level.SEVERE, ioEx, () -> errorMsg);
                 }
             }
         }

--- a/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/enrichment/EnrichFromGraphMLPlugin.java
+++ b/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/enrichment/EnrichFromGraphMLPlugin.java
@@ -30,6 +30,7 @@ import au.gov.asd.tac.constellation.plugins.parameters.PluginParameter;
 import au.gov.asd.tac.constellation.plugins.parameters.PluginParameters;
 import au.gov.asd.tac.constellation.plugins.parameters.types.FileParameterType;
 import au.gov.asd.tac.constellation.plugins.parameters.types.FileParameterType.FileParameterValue;
+import au.gov.asd.tac.constellation.utilities.gui.NotifyDisplayer;
 import au.gov.asd.tac.constellation.utilities.xml.XmlUtilities;
 import au.gov.asd.tac.constellation.views.dataaccess.plugins.DataAccessPlugin;
 import au.gov.asd.tac.constellation.views.dataaccess.plugins.DataAccessPluginCoreType;
@@ -46,6 +47,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javafx.stage.FileChooser;
 import javax.xml.transform.TransformerException;
+import org.apache.commons.lang3.StringUtils;
 import org.openide.util.NbBundle.Messages;
 import org.openide.util.lookup.ServiceProvider;
 import org.openide.util.lookup.ServiceProviders;
@@ -194,8 +196,11 @@ public class EnrichFromGraphMLPlugin extends RecordStoreQueryPlugin implements D
                     }
                 }
             } catch (final FileNotFoundException ex) {
-                interaction.notify(PluginNotificationLevel.ERROR, "File " + filename + " not found");
-                LOGGER.log(Level.SEVERE, ex, () -> "File " + filename + " not found");
+                final String errorMsg = StringUtils.isEmpty(filename) ? "File not specified" : "File not found: " + filename;
+                interaction.notify(PluginNotificationLevel.ERROR, errorMsg);
+                final Throwable fnfEx = new FileNotFoundException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
+                fnfEx.setStackTrace(ex.getStackTrace());
+                LOGGER.log(Level.SEVERE, fnfEx, () -> errorMsg);
             } catch (final TransformerException ex) {
                 LOGGER.log(Level.SEVERE, ex.getLocalizedMessage(), ex);
             } finally {
@@ -203,8 +208,11 @@ public class EnrichFromGraphMLPlugin extends RecordStoreQueryPlugin implements D
                     try {
                         in.close();
                     } catch (final IOException ex) {
-                        interaction.notify(PluginNotificationLevel.ERROR, "Error reading file: " + filename);
-                        LOGGER.log(Level.SEVERE, ex, () -> "Error reading file: " + filename);
+                        final String errorMsg = StringUtils.isEmpty(filename) ? "File not specified " : "Error reading file: " + filename;
+                        interaction.notify(PluginNotificationLevel.ERROR, errorMsg);
+                        final Throwable ioEx = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
+                        ioEx.setStackTrace(ex.getStackTrace());            
+                        LOGGER.log(Level.SEVERE, ioEx, () -> errorMsg);
                     }
                 }
             }

--- a/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/extend/ExtendFromGDELTPlugin.java
+++ b/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/extend/ExtendFromGDELTPlugin.java
@@ -23,6 +23,7 @@ import au.gov.asd.tac.constellation.plugins.Plugin;
 import au.gov.asd.tac.constellation.plugins.PluginException;
 import au.gov.asd.tac.constellation.plugins.PluginInfo;
 import au.gov.asd.tac.constellation.plugins.PluginInteraction;
+import au.gov.asd.tac.constellation.plugins.PluginNotificationLevel;
 import au.gov.asd.tac.constellation.plugins.PluginType;
 import au.gov.asd.tac.constellation.plugins.parameters.PluginParameter;
 import au.gov.asd.tac.constellation.plugins.parameters.PluginParameters;
@@ -30,6 +31,7 @@ import au.gov.asd.tac.constellation.plugins.parameters.types.IntegerParameterTyp
 import au.gov.asd.tac.constellation.plugins.parameters.types.IntegerParameterType.IntegerParameterValue;
 import au.gov.asd.tac.constellation.plugins.parameters.types.MultiChoiceParameterType;
 import au.gov.asd.tac.constellation.plugins.parameters.types.MultiChoiceParameterType.MultiChoiceParameterValue;
+import au.gov.asd.tac.constellation.utilities.gui.NotifyDisplayer;
 import au.gov.asd.tac.constellation.views.dataaccess.CoreGlobalParameters;
 import au.gov.asd.tac.constellation.views.dataaccess.adaptors.plugins.utilities.GDELTDateTime;
 import au.gov.asd.tac.constellation.views.dataaccess.adaptors.plugins.utilities.GDELTExtendingUtilities;
@@ -37,6 +39,7 @@ import au.gov.asd.tac.constellation.views.dataaccess.adaptors.plugins.utilities.
 import au.gov.asd.tac.constellation.views.dataaccess.plugins.DataAccessPlugin;
 import au.gov.asd.tac.constellation.views.dataaccess.plugins.DataAccessPluginCoreType;
 import au.gov.asd.tac.constellation.views.dataaccess.templates.RecordStoreQueryPlugin;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -124,8 +127,18 @@ public class ExtendFromGDELTPlugin extends RecordStoreQueryPlugin implements Dat
                 final RecordStore results = GDELTExtendingUtilities.hopRelationships(gdt, options, limit, labels);
                 interaction.setProgress(1, 0, "Completed successfully - added " + results.size() + " entities.", true);
                 return results;
+            } catch (final FileNotFoundException ex) {
+                final String errorMsg = "File not found: " + ex.getLocalizedMessage();
+                interaction.notify(PluginNotificationLevel.ERROR, errorMsg);
+                final Throwable fnfEx = new FileNotFoundException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
+                fnfEx.setStackTrace(ex.getStackTrace());
+                LOGGER.log(Level.SEVERE, fnfEx, () -> errorMsg);
             } catch (final IOException ex) {
-                LOGGER.log(Level.SEVERE, ex.getLocalizedMessage(), ex);
+                final String errorMsg = "Error reading file: " + ex.getLocalizedMessage();
+                interaction.notify(PluginNotificationLevel.ERROR, errorMsg);
+                final Throwable ioEx = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
+                ioEx.setStackTrace(ex.getStackTrace());
+                LOGGER.log(Level.SEVERE, ioEx, () -> errorMsg);
             }
         }
 

--- a/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/extend/ExtendFromGMLPlugin.java
+++ b/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/extend/ExtendFromGMLPlugin.java
@@ -32,6 +32,7 @@ import au.gov.asd.tac.constellation.plugins.parameters.types.BooleanParameterTyp
 import au.gov.asd.tac.constellation.plugins.parameters.types.BooleanParameterType.BooleanParameterValue;
 import au.gov.asd.tac.constellation.plugins.parameters.types.FileParameterType;
 import au.gov.asd.tac.constellation.plugins.parameters.types.FileParameterType.FileParameterValue;
+import au.gov.asd.tac.constellation.utilities.gui.NotifyDisplayer;
 import au.gov.asd.tac.constellation.views.dataaccess.plugins.DataAccessPlugin;
 import au.gov.asd.tac.constellation.views.dataaccess.plugins.DataAccessPluginCoreType;
 import au.gov.asd.tac.constellation.views.dataaccess.templates.RecordStoreQueryPlugin;
@@ -46,6 +47,7 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javafx.stage.FileChooser;
+import org.apache.commons.lang3.StringUtils;
 import org.openide.util.NbBundle.Messages;
 import org.openide.util.lookup.ServiceProvider;
 import org.openide.util.lookup.ServiceProviders;
@@ -176,18 +178,27 @@ public class ExtendFromGMLPlugin extends RecordStoreQueryPlugin implements DataA
                 }
 
             } catch (final FileNotFoundException ex) {
-                interaction.notify(PluginNotificationLevel.ERROR, "File " + filename + " not found");
-                LOGGER.log(Level.SEVERE, ex, () -> "File " + filename + " not found");
+                final String errorMsg = StringUtils.isEmpty(filename) ? "File not specified" : "File not found: " + filename;
+                interaction.notify(PluginNotificationLevel.ERROR, errorMsg);
+                final Throwable fnfEx = new FileNotFoundException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
+                fnfEx.setStackTrace(ex.getStackTrace());
+                LOGGER.log(Level.SEVERE, fnfEx, () -> errorMsg);
             } catch (final IOException ex) {
-                interaction.notify(PluginNotificationLevel.ERROR, "Error reading file: " + filename);
-                LOGGER.log(Level.SEVERE, ex, () -> "Error reading file: " + filename);
+                final String errorMsg = StringUtils.isEmpty(filename) ? "File not specified " : "Error reading file: " + filename;
+                interaction.notify(PluginNotificationLevel.ERROR, errorMsg);
+                final Throwable ioEx = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
+                ioEx.setStackTrace(ex.getStackTrace());
+                LOGGER.log(Level.SEVERE, ioEx, () -> errorMsg);
             } finally {
                 if (in != null) {
                     try {
                         in.close();
                     } catch (final IOException ex) {
-                        interaction.notify(PluginNotificationLevel.ERROR, "Error reading file: " + filename);
-                        LOGGER.log(Level.SEVERE, ex, () -> "Error reading file: " + filename);
+                        final String errorMsg = StringUtils.isEmpty(filename) ? "File not specified " : "Error reading file: " + filename;
+                        interaction.notify(PluginNotificationLevel.ERROR, errorMsg);
+                        final Throwable ioEx = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
+                        ioEx.setStackTrace(ex.getStackTrace());
+                        LOGGER.log(Level.SEVERE, ioEx, () -> errorMsg);
                     }
                 }
             }

--- a/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/extend/ExtendFromGraphMLPlugin.java
+++ b/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/extend/ExtendFromGraphMLPlugin.java
@@ -32,6 +32,7 @@ import au.gov.asd.tac.constellation.plugins.parameters.types.BooleanParameterTyp
 import au.gov.asd.tac.constellation.plugins.parameters.types.BooleanParameterType.BooleanParameterValue;
 import au.gov.asd.tac.constellation.plugins.parameters.types.FileParameterType;
 import au.gov.asd.tac.constellation.plugins.parameters.types.FileParameterType.FileParameterValue;
+import au.gov.asd.tac.constellation.utilities.gui.NotifyDisplayer;
 import au.gov.asd.tac.constellation.utilities.xml.XmlUtilities;
 import au.gov.asd.tac.constellation.views.dataaccess.plugins.DataAccessPlugin;
 import au.gov.asd.tac.constellation.views.dataaccess.plugins.DataAccessPluginCoreType;
@@ -50,6 +51,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javafx.stage.FileChooser;
 import javax.xml.transform.TransformerException;
+import org.apache.commons.lang3.StringUtils;
 import org.openide.util.NbBundle.Messages;
 import org.openide.util.lookup.ServiceProvider;
 import org.openide.util.lookup.ServiceProviders;
@@ -292,8 +294,11 @@ public class ExtendFromGraphMLPlugin extends RecordStoreQueryPlugin implements D
                         }
                     }
                 } catch (final FileNotFoundException ex) {
-                    interaction.notify(PluginNotificationLevel.ERROR, "File " + filename + " not found");
-                    LOGGER.log(Level.SEVERE, ex, () -> "File " + filename + " not found");
+                    final String errorMsg = StringUtils.isEmpty(filename) ? "File not specified" : "File not found: " + filename;
+                    interaction.notify(PluginNotificationLevel.ERROR, errorMsg);
+                    final Throwable fnfEx = new FileNotFoundException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
+                    fnfEx.setStackTrace(ex.getStackTrace());
+                    LOGGER.log(Level.SEVERE, fnfEx, () -> errorMsg);
                 } catch (final TransformerException ex) {
                     LOGGER.log(Level.SEVERE, ex.getLocalizedMessage(), ex);
                 } finally {
@@ -301,8 +306,11 @@ public class ExtendFromGraphMLPlugin extends RecordStoreQueryPlugin implements D
                         try {
                             in.close();
                         } catch (final IOException ex) {
-                            interaction.notify(PluginNotificationLevel.ERROR, "Error reading file: " + filename);
-                            LOGGER.log(Level.SEVERE, ex, () -> "Error reading file: " + filename);
+                            final String errorMsg = StringUtils.isEmpty(filename) ? "File not specified " : "Error reading file: " + filename;
+                            interaction.notify(PluginNotificationLevel.ERROR, errorMsg);
+                            final Throwable ioEx = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
+                            ioEx.setStackTrace(ex.getStackTrace());            
+                            LOGGER.log(Level.SEVERE, ioEx, () -> errorMsg);
                         }
                     }
                 }

--- a/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/extend/ExtendFromPajekPlugin.java
+++ b/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/extend/ExtendFromPajekPlugin.java
@@ -32,6 +32,7 @@ import au.gov.asd.tac.constellation.plugins.parameters.types.BooleanParameterTyp
 import au.gov.asd.tac.constellation.plugins.parameters.types.BooleanParameterType.BooleanParameterValue;
 import au.gov.asd.tac.constellation.plugins.parameters.types.FileParameterType;
 import au.gov.asd.tac.constellation.plugins.parameters.types.FileParameterType.FileParameterValue;
+import au.gov.asd.tac.constellation.utilities.gui.NotifyDisplayer;
 import au.gov.asd.tac.constellation.views.dataaccess.plugins.DataAccessPlugin;
 import au.gov.asd.tac.constellation.views.dataaccess.plugins.DataAccessPluginCoreType;
 import au.gov.asd.tac.constellation.views.dataaccess.templates.RecordStoreQueryPlugin;
@@ -46,6 +47,7 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javafx.stage.FileChooser;
+import org.apache.commons.lang3.StringUtils;
 import org.openide.util.NbBundle.Messages;
 import org.openide.util.lookup.ServiceProvider;
 import org.openide.util.lookup.ServiceProviders;
@@ -199,18 +201,27 @@ public class ExtendFromPajekPlugin extends RecordStoreQueryPlugin implements Dat
                     }
                     interaction.setProgress(1, 0, "Completed successfully - added " + result.size() + " entities.", true);
                 } catch (final FileNotFoundException ex) {
-                    interaction.notify(PluginNotificationLevel.ERROR, "File " + filename + " not found");
-                    LOGGER.log(Level.SEVERE, ex, () -> "File " + filename + " not found");
+                    final String errorMsg = StringUtils.isEmpty(filename) ? "File not specified" : "File not found: " + filename;
+                    interaction.notify(PluginNotificationLevel.ERROR, errorMsg);
+                    final Throwable fnfEx = new FileNotFoundException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
+                    fnfEx.setStackTrace(ex.getStackTrace());
+                    LOGGER.log(Level.SEVERE, fnfEx, () -> errorMsg);
                 } catch (final IOException ex) {
-                    interaction.notify(PluginNotificationLevel.ERROR, "Error reading file: " + filename);
-                    LOGGER.log(Level.SEVERE, ex, () -> "Error reading file: " + filename);
+                    final String errorMsg = StringUtils.isEmpty(filename) ? "File not specified " : "Error reading file: " + filename;
+                    interaction.notify(PluginNotificationLevel.ERROR, errorMsg);
+                    final Throwable ioEx = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
+                    ioEx.setStackTrace(ex.getStackTrace());
+                    LOGGER.log(Level.SEVERE, ioEx, () -> errorMsg);
                 } finally {
                     if (in != null) {
                         try {
                             in.close();
                         } catch (final IOException ex) {
-                            interaction.notify(PluginNotificationLevel.ERROR, "Error reading file: " + filename);
-                            LOGGER.log(Level.SEVERE, ex, () -> "Error reading file: " + filename);
+                            final String errorMsg = StringUtils.isEmpty(filename) ? "File not specified " : "Error reading file: " + filename;
+                            interaction.notify(PluginNotificationLevel.ERROR, errorMsg);
+                            final Throwable ioEx = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
+                            ioEx.setStackTrace(ex.getStackTrace());
+                            LOGGER.log(Level.SEVERE, ioEx, () -> errorMsg);
                         }
                     }
                 }

--- a/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/importing/ImportEntitiesFromGDELTPlugin.java
+++ b/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/importing/ImportEntitiesFromGDELTPlugin.java
@@ -21,6 +21,7 @@ import au.gov.asd.tac.constellation.plugins.Plugin;
 import au.gov.asd.tac.constellation.plugins.PluginException;
 import au.gov.asd.tac.constellation.plugins.PluginInfo;
 import au.gov.asd.tac.constellation.plugins.PluginInteraction;
+import au.gov.asd.tac.constellation.plugins.PluginNotificationLevel;
 import au.gov.asd.tac.constellation.plugins.PluginType;
 import au.gov.asd.tac.constellation.plugins.parameters.PluginParameter;
 import au.gov.asd.tac.constellation.plugins.parameters.PluginParameters;
@@ -28,6 +29,7 @@ import au.gov.asd.tac.constellation.plugins.parameters.types.IntegerParameterTyp
 import au.gov.asd.tac.constellation.plugins.parameters.types.IntegerParameterType.IntegerParameterValue;
 import au.gov.asd.tac.constellation.plugins.parameters.types.MultiChoiceParameterType;
 import au.gov.asd.tac.constellation.plugins.parameters.types.MultiChoiceParameterType.MultiChoiceParameterValue;
+import au.gov.asd.tac.constellation.utilities.gui.NotifyDisplayer;
 import au.gov.asd.tac.constellation.views.dataaccess.CoreGlobalParameters;
 import au.gov.asd.tac.constellation.views.dataaccess.adaptors.plugins.utilities.GDELTDateTime;
 import au.gov.asd.tac.constellation.views.dataaccess.adaptors.plugins.utilities.GDELTEntityTypes;
@@ -35,6 +37,7 @@ import au.gov.asd.tac.constellation.views.dataaccess.adaptors.plugins.utilities.
 import au.gov.asd.tac.constellation.views.dataaccess.plugins.DataAccessPlugin;
 import au.gov.asd.tac.constellation.views.dataaccess.plugins.DataAccessPluginCoreType;
 import au.gov.asd.tac.constellation.views.dataaccess.templates.RecordStoreQueryPlugin;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -121,8 +124,18 @@ public class ImportEntitiesFromGDELTPlugin extends RecordStoreQueryPlugin implem
                 final RecordStore results = GDELTImportingUtilities.retrieveEntities(gdt, options, limit);
                 interaction.setProgress(1, 0, "Completed successfully - added " + results.size() + " entities.", true);
                 return results;
+            } catch (final FileNotFoundException ex) {
+                final String errorMsg = "File not found: " + ex.getLocalizedMessage();
+                interaction.notify(PluginNotificationLevel.ERROR, errorMsg);
+                final Throwable fnfEx = new FileNotFoundException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
+                fnfEx.setStackTrace(ex.getStackTrace());
+                LOGGER.log(Level.SEVERE, fnfEx, () -> errorMsg);
             } catch (final IOException ex) {
-                LOGGER.log(Level.SEVERE, ex.getLocalizedMessage(), ex);
+                final String errorMsg = "Error reading file: " + ex.getLocalizedMessage();
+                interaction.notify(PluginNotificationLevel.ERROR, errorMsg);
+                final Throwable ioEx = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
+                ioEx.setStackTrace(ex.getStackTrace());
+                LOGGER.log(Level.SEVERE, ioEx, () -> errorMsg);
             }
         }
 

--- a/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/importing/ImportRelationshipsFromGDELTPlugin.java
+++ b/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/importing/ImportRelationshipsFromGDELTPlugin.java
@@ -21,6 +21,7 @@ import au.gov.asd.tac.constellation.plugins.Plugin;
 import au.gov.asd.tac.constellation.plugins.PluginException;
 import au.gov.asd.tac.constellation.plugins.PluginInfo;
 import au.gov.asd.tac.constellation.plugins.PluginInteraction;
+import au.gov.asd.tac.constellation.plugins.PluginNotificationLevel;
 import au.gov.asd.tac.constellation.plugins.PluginType;
 import au.gov.asd.tac.constellation.plugins.parameters.PluginParameter;
 import au.gov.asd.tac.constellation.plugins.parameters.PluginParameters;
@@ -28,6 +29,7 @@ import au.gov.asd.tac.constellation.plugins.parameters.types.IntegerParameterTyp
 import au.gov.asd.tac.constellation.plugins.parameters.types.IntegerParameterType.IntegerParameterValue;
 import au.gov.asd.tac.constellation.plugins.parameters.types.MultiChoiceParameterType;
 import au.gov.asd.tac.constellation.plugins.parameters.types.MultiChoiceParameterType.MultiChoiceParameterValue;
+import au.gov.asd.tac.constellation.utilities.gui.NotifyDisplayer;
 import au.gov.asd.tac.constellation.views.dataaccess.CoreGlobalParameters;
 import au.gov.asd.tac.constellation.views.dataaccess.adaptors.plugins.utilities.GDELTDateTime;
 import au.gov.asd.tac.constellation.views.dataaccess.adaptors.plugins.utilities.GDELTImportingUtilities;
@@ -35,6 +37,7 @@ import au.gov.asd.tac.constellation.views.dataaccess.adaptors.plugins.utilities.
 import au.gov.asd.tac.constellation.views.dataaccess.plugins.DataAccessPlugin;
 import au.gov.asd.tac.constellation.views.dataaccess.plugins.DataAccessPluginCoreType;
 import au.gov.asd.tac.constellation.views.dataaccess.templates.RecordStoreQueryPlugin;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -121,8 +124,18 @@ public class ImportRelationshipsFromGDELTPlugin extends RecordStoreQueryPlugin i
                 final RecordStore results = GDELTImportingUtilities.retrieveRelationships(gdt, options, limit);
                 interaction.setProgress(1, 0, "Completed successfully - added " + results.size() + " entities.", true);
                 return results;
+            } catch (final FileNotFoundException ex) {
+                final String errorMsg = "File not found: " + ex.getLocalizedMessage();
+                interaction.notify(PluginNotificationLevel.ERROR, errorMsg);
+                final Throwable fnfEx = new FileNotFoundException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
+                fnfEx.setStackTrace(ex.getStackTrace());
+                LOGGER.log(Level.SEVERE, fnfEx, () -> errorMsg);
             } catch (final IOException ex) {
-                LOGGER.log(Level.SEVERE, ex.getLocalizedMessage(), ex);
+                final String errorMsg = "Error reading file: " + ex.getLocalizedMessage();
+                interaction.notify(PluginNotificationLevel.ERROR, errorMsg);
+                final Throwable ioEx = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
+                ioEx.setStackTrace(ex.getStackTrace());
+                LOGGER.log(Level.SEVERE, ioEx, () -> errorMsg);
             }
         }
 


### PR DESCRIPTION
Addressing issue raised in core constellation ticket #1839

Should only get a single notification when an error occurs.
Any exceptions that are also logged will appear in the Error Report View.
Should not see an Exception popup message if there was a notification window shown.