### PR TITLE
Fix GDELT Plugins

### DIFF
--- a/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/extend/ExtendFromGDELTPlugin.java
+++ b/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/extend/ExtendFromGDELTPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2021 Australian Signals Directorate
+ * Copyright 2010-2024 Australian Signals Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,10 @@ import au.gov.asd.tac.constellation.views.dataaccess.plugins.DataAccessPluginCor
 import au.gov.asd.tac.constellation.views.dataaccess.templates.RecordStoreQueryPlugin;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
@@ -124,7 +127,16 @@ public class ExtendFromGDELTPlugin extends RecordStoreQueryPlugin implements Dat
         if (end != null) {
             try {
                 final GDELTDateTime gdt = new GDELTDateTime(end);
-                final RecordStore results = GDELTExtendingUtilities.hopRelationships(gdt, options, limit, labels);
+                RecordStore results = GDELTExtendingUtilities.hopRelationships(gdt, options, limit, labels);
+                
+                LocalDate date = LocalDate.parse(gdt.day, DateTimeFormatter.ISO_DATE);
+                while (results == null) {
+                    date = date.minusDays(1);
+                    final ZonedDateTime dateTime = date.atStartOfDay(ZoneId.systemDefault());
+                    final GDELTDateTime newGdt = new GDELTDateTime(dateTime);
+                    results = GDELTExtendingUtilities.hopRelationships(newGdt, options, limit, labels);
+                }
+                
                 interaction.setProgress(1, 0, "Completed successfully - added " + results.size() + " entities.", true);
                 return results;
             } catch (final FileNotFoundException ex) {

--- a/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/importing/ImportEntitiesFromGDELTPlugin.java
+++ b/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/importing/ImportEntitiesFromGDELTPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2021 Australian Signals Directorate
+ * Copyright 2010-2024 Australian Signals Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,10 @@ import au.gov.asd.tac.constellation.views.dataaccess.plugins.DataAccessPluginCor
 import au.gov.asd.tac.constellation.views.dataaccess.templates.RecordStoreQueryPlugin;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
@@ -117,13 +120,22 @@ public class ImportEntitiesFromGDELTPlugin extends RecordStoreQueryPlugin implem
 
         final ZonedDateTime[] startEnd = CoreGlobalParameters.DATETIME_RANGE_PARAMETER.getDateTimeRangeValue().getZonedStartEnd();
         final ZonedDateTime end = startEnd[1];
-
+        
         if (end != null) {
             try {
                 final GDELTDateTime gdt = new GDELTDateTime(end);
-                final RecordStore results = GDELTImportingUtilities.retrieveEntities(gdt, options, limit);
+                RecordStore results = GDELTImportingUtilities.retrieveEntities(gdt, options, limit);
+                
+                LocalDate date = LocalDate.parse(gdt.day, DateTimeFormatter.ISO_DATE);
+                while (results == null) {
+                    date = date.minusDays(1);
+                    final ZonedDateTime dateTime = date.atStartOfDay(ZoneId.systemDefault());
+                    final GDELTDateTime newGdt = new GDELTDateTime(dateTime);
+                    results = GDELTImportingUtilities.retrieveEntities(newGdt, options, limit);
+                }
                 interaction.setProgress(1, 0, "Completed successfully - added " + results.size() + " entities.", true);
                 return results;
+                
             } catch (final FileNotFoundException ex) {
                 final String errorMsg = "File not found: " + ex.getLocalizedMessage();
                 interaction.notify(PluginNotificationLevel.ERROR, errorMsg);

--- a/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/utilities/GDELTDateTime.java
+++ b/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/utilities/GDELTDateTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2021 Australian Signals Directorate
+ * Copyright 2010-2024 Australian Signals Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,23 +28,25 @@ public class GDELTDateTime {
     private static final String FOOTER = ".gkg.csv";
     private static final String ZIPPER = ".zip";
 
-    private final int h;
+    private final int y;
     private final int m;
     private final int d;
 
-    private final String day;
+    public final String day;
+    public final String date;
     public final String dt;
     public final String url;
     public final String file;
 
-    public GDELTDateTime(ZonedDateTime date) {
-        this.h = date.getYear();
-        this.m = date.getMonthValue();
-        this.d = date.getDayOfMonth();
+    public GDELTDateTime(final ZonedDateTime dateTime) {
+        this.y = dateTime.getYear();
+        this.m = dateTime.getMonthValue();
+        this.d = dateTime.getDayOfMonth();
 
-        this.day = String.format("%04d%02d%02d", h, m, d);
-        this.dt = String.format("%04d-%02d-%02d 00:00:00.000Z", h, m, d);
-        this.url = HEADER + day + FOOTER + ZIPPER;
-        this.file = day + FOOTER;
+        this.day = String.format("%04d-%02d-%02d", y, m, d);
+        this.date = String.format("%04d%02d%02d", y, m, d);
+        this.dt = String.format("%04d-%02d-%02d 00:00:00.000Z", y, m, d);
+        this.url = HEADER + date + FOOTER + ZIPPER;
+        this.file = date + FOOTER;
     }
 }

--- a/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/utilities/GDELTExtendingUtilities.java
+++ b/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/utilities/GDELTExtendingUtilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2021 Australian Signals Directorate
+ * Copyright 2010-2024 Australian Signals Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,11 +23,13 @@ import au.gov.asd.tac.constellation.graph.schema.analytic.concept.SpatialConcept
 import au.gov.asd.tac.constellation.graph.schema.analytic.concept.TemporalConcept;
 import au.gov.asd.tac.constellation.graph.schema.visual.concept.VisualConcept;
 import java.io.BufferedReader;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -38,28 +40,27 @@ import java.util.zip.ZipInputStream;
  */
 public class GDELTExtendingUtilities {
 
-    public static RecordStore hopRelationships(GDELTDateTime gdt, List<String> options, int limit, List<String> labels) throws MalformedURLException, IOException {
+    private static final Logger LOGGER = Logger.getLogger(GDELTExtendingUtilities.class.getName());
 
-        ZipInputStream zis = null;
+    public static RecordStore hopRelationships(final GDELTDateTime gdt, final List<String> options, final int limit, final List<String> labels) throws IOException {
+
         RecordStore results = null;
-        try {
-            zis = new ZipInputStream(new URL(gdt.url).openStream());
+        try (final ZipInputStream zis = new ZipInputStream(new URL(gdt.url).openStream())) {
 
             final ZipEntry ze = zis.getNextEntry();
             if (ze.getName().equals(gdt.file)) {
                 results = readRelationshipsToHop(limit, gdt.dt, options, ze, zis, labels);
             }
 
-        } finally {
-            if (zis != null) {
-                zis.close();
-            }
+        } catch (final FileNotFoundException ex) {
+            final String errorMsg = "File not found " + ex.getLocalizedMessage();
+            LOGGER.log(Level.WARNING, errorMsg);
         }
 
         return results;
     }
 
-    public static RecordStore readRelationshipsToHop(int limit, String dt, List<String> options, ZipEntry ze, ZipInputStream zis, List<String> labels) throws IOException {
+    public static RecordStore readRelationshipsToHop(final int limit, final String dt, final List<String> options, final ZipEntry ze, final ZipInputStream zis, final List<String> labels) throws IOException {
         final RecordStore results = new GraphRecordStore();
         int total = 0;
         BufferedReader br = null;
@@ -97,7 +98,7 @@ public class GDELTExtendingUtilities {
                                 if (total >= limit) {
                                     break;
                                 }
-                                if (options.contains("Person - Person")) {
+                                if (options.contains("Person_Person")) {
                                     for (int j = 0; j < persons.length; j++) {
                                         total++;
                                         if (total >= limit) {
@@ -122,7 +123,7 @@ public class GDELTExtendingUtilities {
                                     }
                                 }
 
-                                if (options.contains("Person - Organisation")) {
+                                if (options.contains("Person_Organisation")) {
                                     for (int j = 0; j < organisations.length; j++) {
                                         total++;
                                         if (total >= limit) {
@@ -143,7 +144,7 @@ public class GDELTExtendingUtilities {
                                         results.set(GraphRecordStoreUtilities.TRANSACTION + "Tone", tone);
                                     }
                                 }
-                                if (options.contains("Person - Theme")) {
+                                if (options.contains("Person_Theme")) {
                                     for (int j = 0; j < themes.length; j++) {
                                         total++;
                                         if (total >= limit) {
@@ -165,7 +166,7 @@ public class GDELTExtendingUtilities {
                                     }
                                 }
 
-                                if (options.contains("Person - Location")) {
+                                if (options.contains("Person_Location")) {
                                     for (int j = 0; j < locations.length; j++) {
                                         total++;
                                         if (total >= limit) {
@@ -188,7 +189,7 @@ public class GDELTExtendingUtilities {
                                     }
                                 }
 
-                                if (options.contains("Person - Source")) {
+                                if (options.contains("Person_Source")) {
                                     for (int j = 0; j < sources.length; j++) {
                                         total++;
                                         if (total >= limit) {
@@ -210,7 +211,7 @@ public class GDELTExtendingUtilities {
                                     }
                                 }
 
-                                if (options.contains("Person - URL")) {
+                                if (options.contains("Person_URL")) {
                                     for (int j = 0; j < sourceURLs.length; j++) {
                                         total++;
                                         if (total >= limit) {
@@ -240,7 +241,7 @@ public class GDELTExtendingUtilities {
                                 if (total >= limit) {
                                     break;
                                 }
-                                if (options.contains("Organisation - Organisation")) {
+                                if (options.contains("Organisation_Organisation")) {
                                     for (int j = 0; j < organisations.length; j++) {
                                         total++;
                                         if (total >= limit) {
@@ -266,7 +267,7 @@ public class GDELTExtendingUtilities {
                                     }
                                 }
 
-                                if (options.contains("Organisation - Theme")) {
+                                if (options.contains("Organisation_Theme")) {
                                     for (int j = 0; j < themes.length; j++) {
                                         total++;
                                         if (total >= limit) {
@@ -288,7 +289,7 @@ public class GDELTExtendingUtilities {
                                     }
                                 }
 
-                                if (options.contains("Organisation - Source")) {
+                                if (options.contains("Organisation_Source")) {
                                     for (int j = 0; j < sources.length; j++) {
                                         total++;
                                         if (total >= limit) {
@@ -310,7 +311,7 @@ public class GDELTExtendingUtilities {
                                     }
                                 }
 
-                                if (options.contains("Organisation - URL")) {
+                                if (options.contains("Organisation_URL")) {
                                     for (int j = 0; j < sourceURLs.length; j++) {
                                         total++;
                                         if (total >= limit) {
@@ -341,7 +342,7 @@ public class GDELTExtendingUtilities {
                                     break;
                                 }
 
-                                if (options.contains("Person - Theme")) {
+                                if (options.contains("Person_Theme")) {
                                     for (int j = 0; j < persons.length; j++) {
                                         total++;
                                         if (total >= limit) {
@@ -363,7 +364,7 @@ public class GDELTExtendingUtilities {
                                     }
                                 }
 
-                                if (options.contains("Organisation - Theme")) {
+                                if (options.contains("Organisation_Theme")) {
                                     for (int j = 0; j < organisations.length; j++) {
                                         total++;
                                         if (total >= limit) {
@@ -394,7 +395,7 @@ public class GDELTExtendingUtilities {
                                     break;
                                 }
 
-                                if (options.contains("Person - Source")) {
+                                if (options.contains("Person_Source")) {
                                     for (int j = 0; j < persons.length; j++) {
                                         total++;
                                         if (total >= limit) {
@@ -415,7 +416,7 @@ public class GDELTExtendingUtilities {
                                         results.set(GraphRecordStoreUtilities.TRANSACTION + "Tone", tone);
                                     }
                                 }
-                                if (options.contains("Organisation - Source")) {
+                                if (options.contains("Organisation_Source")) {
                                     for (int j = 0; j < organisations.length; j++) {
                                         total++;
                                         if (total >= limit) {
@@ -446,7 +447,7 @@ public class GDELTExtendingUtilities {
                                     break;
                                 }
 
-                                if (options.contains("Person - URL")) {
+                                if (options.contains("Person_URL")) {
                                     for (int j = 0; j < persons.length; j++) {
                                         total++;
                                         if (total >= limit) {
@@ -467,7 +468,7 @@ public class GDELTExtendingUtilities {
                                         results.set(GraphRecordStoreUtilities.TRANSACTION + "Tone", tone);
                                     }
                                 }
-                                if (options.contains("Organisation - URL")) {
+                                if (options.contains("Organisation_URL")) {
                                     for (int j = 0; j < organisations.length; j++) {
                                         total++;
                                         if (total >= limit) {
@@ -498,7 +499,7 @@ public class GDELTExtendingUtilities {
                                     break;
                                 }
 
-                                if (options.contains("Person - Location")) {
+                                if (options.contains("Person_Location")) {
                                     for (int j = 0; j < persons.length; j++) {
                                         total++;
                                         if (total >= limit) {

--- a/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/utilities/GDELTImportingUtilities.java
+++ b/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/utilities/GDELTImportingUtilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2021 Australian Signals Directorate
+ * Copyright 2010-2024 Australian Signals Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,11 +23,13 @@ import au.gov.asd.tac.constellation.graph.schema.analytic.concept.SpatialConcept
 import au.gov.asd.tac.constellation.graph.schema.analytic.concept.TemporalConcept;
 import au.gov.asd.tac.constellation.graph.schema.visual.concept.VisualConcept;
 import java.io.BufferedReader;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -39,49 +41,45 @@ import java.util.zip.ZipInputStream;
  */
 public class GDELTImportingUtilities {
 
-    public static RecordStore retrieveEntities(GDELTDateTime gdt, List<String> options, int limit) throws MalformedURLException, IOException {
+    private static final Logger LOGGER = Logger.getLogger(GDELTImportingUtilities.class.getName());
 
-        ZipInputStream zis = null;
+    public static RecordStore retrieveEntities(final GDELTDateTime gdt, final List<String> options, final int limit) throws IOException {
+
         RecordStore results = null;
-        try {
-            zis = new ZipInputStream(new URL(gdt.url).openStream());
-
+        try (final ZipInputStream zis = new ZipInputStream(new URL(gdt.url).openStream())) {
+            
             final ZipEntry ze = zis.getNextEntry();
             if (ze.getName().equals(gdt.file)) {
                 results = readEntities(limit, gdt.dt, options, ze, zis);
             }
 
-        } finally {
-            if (zis != null) {
-                zis.close();
-            }
+        } catch (final FileNotFoundException ex) {
+            final String errorMsg = "File not found " + ex.getLocalizedMessage();
+            LOGGER.log(Level.WARNING, errorMsg);
         }
 
         return results;
     }
 
-    public static RecordStore retrieveRelationships(GDELTDateTime gdt, List<String> options, int limit) throws MalformedURLException, IOException {
+    public static RecordStore retrieveRelationships(final GDELTDateTime gdt, final List<String> options, final int limit) throws IOException {
 
-        ZipInputStream zis = null;
         RecordStore results = null;
-        try {
-            zis = new ZipInputStream(new URL(gdt.url).openStream());
-
+        try (final ZipInputStream zis = new ZipInputStream(new URL(gdt.url).openStream())) {
+            
             final ZipEntry ze = zis.getNextEntry();
             if (ze.getName().equals(gdt.file)) {
                 results = readRelationships(limit, gdt.dt, options, ze, zis);
             }
 
-        } finally {
-            if (zis != null) {
-                zis.close();
-            }
+        } catch (final FileNotFoundException ex) {
+            final String errorMsg = "File not found " + ex.getLocalizedMessage();
+            LOGGER.log(Level.WARNING, errorMsg);
         }
 
         return results;
     }
 
-    public static RecordStore readEntities(int limit, String dt, List<String> options, ZipEntry ze, ZipInputStream zis) throws IOException {
+    public static RecordStore readEntities(final int limit, final String dt, final List<String> options, final ZipEntry ze, final ZipInputStream zis) throws IOException {
         final RecordStore results = new GraphRecordStore();
         int total = 0;
         BufferedReader br = null;
@@ -197,7 +195,7 @@ public class GDELTImportingUtilities {
         return results;
     }
 
-    public static RecordStore readRelationships(int limit, String dt, List<String> options, ZipEntry ze, ZipInputStream zis) throws IOException {
+    public static RecordStore readRelationships(final int limit, final String dt, final List<String> options, final ZipEntry ze, final ZipInputStream zis) throws IOException {
         final RecordStore results = new GraphRecordStore();
         int total = 0;
         BufferedReader br = null;
@@ -225,7 +223,7 @@ public class GDELTImportingUtilities {
                     if (total >= limit) {
                         break;
                     }
-                    if (options.contains("Person - Person")) {
+                    if (options.contains("Person_Person")) {
                         for (int j = i + 1; j < persons.length; j++) {
                             total++;
                             if (total >= limit) {
@@ -247,7 +245,7 @@ public class GDELTImportingUtilities {
                         }
                     }
 
-                    if (options.contains("Person - Organisation")) {
+                    if (options.contains("Person_Organisation")) {
                         for (int j = 0; j < organisations.length; j++) {
                             total++;
                             if (total >= limit) {
@@ -268,7 +266,7 @@ public class GDELTImportingUtilities {
                             results.set(GraphRecordStoreUtilities.TRANSACTION + "Tone", tone);
                         }
                     }
-                    if (options.contains("Person - Theme")) {
+                    if (options.contains("Person_Theme")) {
                         for (int j = 0; j < themes.length; j++) {
                             total++;
                             if (total >= limit) {
@@ -290,7 +288,7 @@ public class GDELTImportingUtilities {
                         }
                     }
 
-                    if (options.contains("Person - Location")) {
+                    if (options.contains("Person_Location")) {
                         for (int j = 0; j < locations.length; j++) {
                             total++;
                             if (total >= limit) {
@@ -313,7 +311,7 @@ public class GDELTImportingUtilities {
                         }
                     }
 
-                    if (options.contains("Person - Source")) {
+                    if (options.contains("Person_Source")) {
                         for (int j = 0; j < sources.length; j++) {
                             total++;
                             if (total >= limit) {
@@ -335,7 +333,7 @@ public class GDELTImportingUtilities {
                         }
                     }
 
-                    if (options.contains("Person - URL")) {
+                    if (options.contains("Person_URL")) {
                         for (int j = 0; j < sourceURLs.length; j++) {
                             total++;
                             if (total >= limit) {
@@ -362,7 +360,7 @@ public class GDELTImportingUtilities {
                     if (total >= limit) {
                         break;
                     }
-                    if (options.contains("Organisation - Organisation")) {
+                    if (options.contains("Organisation_Organisation")) {
                         for (int j = i + 1; j < organisations.length; j++) {
                             total++;
                             if (total >= limit) {
@@ -384,7 +382,7 @@ public class GDELTImportingUtilities {
                         }
                     }
 
-                    if (options.contains("Organisation - Theme")) {
+                    if (options.contains("Organisation_Theme")) {
                         for (int j = 0; j < themes.length; j++) {
                             total++;
                             if (total >= limit) {
@@ -406,7 +404,7 @@ public class GDELTImportingUtilities {
                         }
                     }
 
-                    if (options.contains("Organisation - Source")) {
+                    if (options.contains("Organisation_Source")) {
                         for (int j = 0; j < sources.length; j++) {
                             total++;
                             if (total >= limit) {
@@ -428,7 +426,7 @@ public class GDELTImportingUtilities {
                         }
                     }
 
-                    if (options.contains("Organisation - URL")) {
+                    if (options.contains("Organisation_URL")) {
                         for (int j = 0; j < sourceURLs.length; j++) {
                             total++;
                             if (total >= limit) {


### PR DESCRIPTION
Description of Change
The GDELT Plugins were set to call the data for the end date of the date range set in the data access view global parameters. The GDELT data is only updated at 6am EST each day with the previous day's data so it would never have today's date there. 
The change made looks at the end date of the date range in the global parameters and attempts to download the data from that date. If the file is not found it goes back a day until it can successfully download a file.

Also updated the relationship options parameters in the Import Relationships from GDELT Knowledge Graph and Extend from GDELT Knowledge Graph to correctly align with the variables in the code as before the code would never find anything selected.

Applicable Issues
[#1952](https://github.com/constellation-app/constellation/issues/1952)