### PR TITLE
GDELT Enrichment shouldn't run if no nodes are selected

### DIFF
--- a/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/extend/ExtendFromGDELTPlugin.java
+++ b/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/extend/ExtendFromGDELTPlugin.java
@@ -123,8 +123,10 @@ public class ExtendFromGDELTPlugin extends RecordStoreQueryPlugin implements Dat
         final ZonedDateTime end = startEnd[1];
 
         final List<String> labels = query.getAll(GraphRecordStoreUtilities.SOURCE + VisualConcept.VertexAttribute.LABEL);
-
-        if (end != null) {
+        
+        if (labels.isEmpty()){
+            interaction.setProgress(0, 0, "Skipped as no nodes were slected", true);
+        } else if (end != null) {
             try {
                 final GDELTDateTime gdt = new GDELTDateTime(end);
                 RecordStore results = GDELTExtendingUtilities.hopRelationships(gdt, options, limit, labels);

--- a/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/extend/ExtendFromGDELTPlugin.java
+++ b/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/extend/ExtendFromGDELTPlugin.java
@@ -124,8 +124,8 @@ public class ExtendFromGDELTPlugin extends RecordStoreQueryPlugin implements Dat
 
         final List<String> labels = query.getAll(GraphRecordStoreUtilities.SOURCE + VisualConcept.VertexAttribute.LABEL);
         
-        if (labels.isEmpty()){
-            interaction.setProgress(0, 0, "Skipped as no nodes were slected", true);
+        if (labels.isEmpty()) {
+            interaction.setProgress(0, 0, "Skipped as no nodes were selected", true);
         } else if (end != null) {
             try {
                 final GDELTDateTime gdt = new GDELTDateTime(end);


### PR DESCRIPTION
### Description of the Change

GDELT enrichment trawls through GDELTS database in reverse chronological order to try and retrieve relationships to elements on a graph. It continues to search until the user specified limit of results is reached. If this plugin is run with no selected nodes, then the plugin attempts to search the entire database as the user specified limit is never reached. 

This PR introduces a check to the plugin to skip its execution and report that it was not run in the event that a user tries to run the plugin with 0 nodes selected. 

This plugin still has the possibility to trawl though the database for an undetermined amount of time if the selected node(s) are not referenced or rarely referenced in the database. 

### Benefits
Makes the Plugin more resilient to unintended use