### PR TITLE
Update adapter plugins ExtensionFilter file types

### DIFF
--- a/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/enrichment/EnrichFromGMLPlugin.java
+++ b/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/enrichment/EnrichFromGMLPlugin.java
@@ -30,6 +30,7 @@ import au.gov.asd.tac.constellation.plugins.parameters.PluginParameter;
 import au.gov.asd.tac.constellation.plugins.parameters.PluginParameters;
 import au.gov.asd.tac.constellation.plugins.parameters.types.FileParameterType;
 import au.gov.asd.tac.constellation.plugins.parameters.types.FileParameterType.FileParameterValue;
+import au.gov.asd.tac.constellation.utilities.file.FileExtensionConstants;
 import au.gov.asd.tac.constellation.utilities.gui.NotifyDisplayer;
 import au.gov.asd.tac.constellation.views.dataaccess.plugins.DataAccessPlugin;
 import au.gov.asd.tac.constellation.views.dataaccess.plugins.DataAccessPluginCoreType;
@@ -90,7 +91,7 @@ public class EnrichFromGMLPlugin extends RecordStoreQueryPlugin implements DataA
 
         // The GML file to read from
         final PluginParameter<FileParameterValue> file = FileParameterType.build(FILE_PARAMETER_ID);
-        FileParameterType.setFileFilters(file, new FileChooser.ExtensionFilter("GML files", "*.gml"));
+        FileParameterType.setFileFilters(file, new FileChooser.ExtensionFilter("GML files", FileExtensionConstants.GML));
         FileParameterType.setKind(file, FileParameterType.FileParameterKind.OPEN);
         file.setName("GML File");
         file.setDescription("File to extract graph from");

--- a/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/enrichment/EnrichFromGraphMLPlugin.java
+++ b/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/enrichment/EnrichFromGraphMLPlugin.java
@@ -30,6 +30,7 @@ import au.gov.asd.tac.constellation.plugins.parameters.PluginParameter;
 import au.gov.asd.tac.constellation.plugins.parameters.PluginParameters;
 import au.gov.asd.tac.constellation.plugins.parameters.types.FileParameterType;
 import au.gov.asd.tac.constellation.plugins.parameters.types.FileParameterType.FileParameterValue;
+import au.gov.asd.tac.constellation.utilities.file.FileExtensionConstants;
 import au.gov.asd.tac.constellation.utilities.gui.NotifyDisplayer;
 import au.gov.asd.tac.constellation.utilities.xml.XmlUtilities;
 import au.gov.asd.tac.constellation.views.dataaccess.plugins.DataAccessPlugin;
@@ -107,7 +108,7 @@ public class EnrichFromGraphMLPlugin extends RecordStoreQueryPlugin implements D
 
         // The GraphML file to read from
         final PluginParameter<FileParameterValue> file = FileParameterType.build(FILE_PARAMETER_ID);
-        FileParameterType.setFileFilters(file, new FileChooser.ExtensionFilter("GraphML files", "*.graphml"));
+        FileParameterType.setFileFilters(file, new FileChooser.ExtensionFilter("GraphML files", FileExtensionConstants.GRAPHML));
         FileParameterType.setKind(file, FileParameterType.FileParameterKind.OPEN);
         file.setName("GraphML File");
         file.setDescription("File to extract attributes from");

--- a/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/extend/ExtendFromGMLPlugin.java
+++ b/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/extend/ExtendFromGMLPlugin.java
@@ -32,6 +32,7 @@ import au.gov.asd.tac.constellation.plugins.parameters.types.BooleanParameterTyp
 import au.gov.asd.tac.constellation.plugins.parameters.types.BooleanParameterType.BooleanParameterValue;
 import au.gov.asd.tac.constellation.plugins.parameters.types.FileParameterType;
 import au.gov.asd.tac.constellation.plugins.parameters.types.FileParameterType.FileParameterValue;
+import au.gov.asd.tac.constellation.utilities.file.FileExtensionConstants;
 import au.gov.asd.tac.constellation.utilities.gui.NotifyDisplayer;
 import au.gov.asd.tac.constellation.views.dataaccess.plugins.DataAccessPlugin;
 import au.gov.asd.tac.constellation.views.dataaccess.plugins.DataAccessPluginCoreType;
@@ -95,7 +96,7 @@ public class ExtendFromGMLPlugin extends RecordStoreQueryPlugin implements DataA
 
         // The GML file to read from
         final PluginParameter<FileParameterValue> file = FileParameterType.build(FILE_PARAMETER_ID);
-        FileParameterType.setFileFilters(file, new FileChooser.ExtensionFilter("GML files", "*.gml"));
+        FileParameterType.setFileFilters(file, new FileChooser.ExtensionFilter("GML files", FileExtensionConstants.GML));
         FileParameterType.setKind(file, FileParameterType.FileParameterKind.OPEN);
         file.setName("GML File");
         file.setDescription("File to extract graph from");

--- a/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/extend/ExtendFromGraphMLPlugin.java
+++ b/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/extend/ExtendFromGraphMLPlugin.java
@@ -32,6 +32,7 @@ import au.gov.asd.tac.constellation.plugins.parameters.types.BooleanParameterTyp
 import au.gov.asd.tac.constellation.plugins.parameters.types.BooleanParameterType.BooleanParameterValue;
 import au.gov.asd.tac.constellation.plugins.parameters.types.FileParameterType;
 import au.gov.asd.tac.constellation.plugins.parameters.types.FileParameterType.FileParameterValue;
+import au.gov.asd.tac.constellation.utilities.file.FileExtensionConstants;
 import au.gov.asd.tac.constellation.utilities.gui.NotifyDisplayer;
 import au.gov.asd.tac.constellation.utilities.xml.XmlUtilities;
 import au.gov.asd.tac.constellation.views.dataaccess.plugins.DataAccessPlugin;
@@ -118,7 +119,7 @@ public class ExtendFromGraphMLPlugin extends RecordStoreQueryPlugin implements D
 
         // The GraphML file to read from
         final PluginParameter<FileParameterValue> file = FileParameterType.build(FILE_PARAMETER_ID);
-        FileParameterType.setFileFilters(file, new FileChooser.ExtensionFilter("GraphML files", "*.graphml"));
+        FileParameterType.setFileFilters(file, new FileChooser.ExtensionFilter("GraphML files", FileExtensionConstants.GRAPHML));
         FileParameterType.setKind(file, FileParameterType.FileParameterKind.OPEN);
         file.setName("GraphML File");
         file.setDescription("File to extract graph from");

--- a/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/extend/ExtendFromPajekPlugin.java
+++ b/AdaptorsDataAccessPlugins/src/au/gov/asd/tac/constellation/views/dataaccess/adaptors/plugins/extend/ExtendFromPajekPlugin.java
@@ -32,6 +32,7 @@ import au.gov.asd.tac.constellation.plugins.parameters.types.BooleanParameterTyp
 import au.gov.asd.tac.constellation.plugins.parameters.types.BooleanParameterType.BooleanParameterValue;
 import au.gov.asd.tac.constellation.plugins.parameters.types.FileParameterType;
 import au.gov.asd.tac.constellation.plugins.parameters.types.FileParameterType.FileParameterValue;
+import au.gov.asd.tac.constellation.utilities.file.FileExtensionConstants;
 import au.gov.asd.tac.constellation.utilities.gui.NotifyDisplayer;
 import au.gov.asd.tac.constellation.views.dataaccess.plugins.DataAccessPlugin;
 import au.gov.asd.tac.constellation.views.dataaccess.plugins.DataAccessPluginCoreType;
@@ -96,7 +97,7 @@ public class ExtendFromPajekPlugin extends RecordStoreQueryPlugin implements Dat
 
         // The Pajek file to read from
         final PluginParameter<FileParameterValue> file = FileParameterType.build(FILE_PARAMETER_ID);
-        FileParameterType.setFileFilters(file, new FileChooser.ExtensionFilter("PAJEK files", "*.net"));
+        FileParameterType.setFileFilters(file, new FileChooser.ExtensionFilter("PAJEK files", FileExtensionConstants.PAJEK));
         FileParameterType.setKind(file, FileParameterType.FileParameterKind.OPEN);
         file.setName("Pajek File");
         file.setDescription("File to extract graph from");


### PR DESCRIPTION
Use FileExtensionConstants for ExtensionFilter for Extend and Enrich plugins in Data Access View to enable filtering of file types in FileChooser.
See [#2228](https://github.com/constellation-app/constellation/issues/2228)